### PR TITLE
Add Nick Launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [SideHunt](https://sidehunt.io) – A discovery platform for side projects and indie hacker creations.
 
 ---
+- [Nick Launches](https://nicklaunches.com/) - Launch platform for builders, AI startups, and SaaS founders to get discovered and earn a permanent dofollow backlink.
 
 ## AI & Tool-Focused Launch Directories
 


### PR DESCRIPTION
Adds Nick Launches to the directory list.

Nick Launches is a launch platform for builders, AI startups, and SaaS founders to get discovered and earn a permanent dofollow backlink.

Edited `README.md` using the repository's existing format (relevant bullet section).