### PR TITLE
Add SaaSCity to Startup & Tool Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Startup Fame](https://startupfa.me) – Product listings and startup discovery.
 - [Findly Tools](https://findly.tools) – Tool discovery and backlink listings.
 - [AIWith.me](https://aiwith.me) – AI and tool showcase platform.
+- [SaaSCity](https://saascity.io) – Gamified SaaS directory where every listing becomes a building on a live isometric city map.
 
 ---
 


### PR DESCRIPTION
Adds **SaaSCity** to the list.

- **URL:** https://saascity.io
- **Submit page:** https://saascity.io/submit
- **Domain Rating:** 46 (Ahrefs)
- **Listing:** free listing with an indexed product page; paid tiers add a dofollow backlink and map placement
- **Review:** every submission is manually reviewed, usually approved within 24h

SaaSCity is a gamified SaaS directory — each listing becomes a building on a live isometric city map.

The entry follows the existing format used in this section.