### PR TITLE
Add Mydentify to directory resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Findly Tools](https://findly.tools) – Tool discovery and backlink listings.
 - [AIWith.me](https://aiwith.me) – AI and tool showcase platform.
 - [SaaSCity](https://saascity.io) – Gamified SaaS directory where every listing becomes a building on a live isometric city map.
+- [Mydentify](https://mydentify.com) – Goal-based product discovery with reviewed listings and a researched launch-directory catalog.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds Mydentify to the **Startup & Tool Directories (Visibility & Backlinks)** section using the list's existing one-line format.

## Why

Mydentify is a goal-based product discovery site with reviewed product listings and a researched catalog of launch directories. It fits the section's focus on product visibility and directory discovery.

## Disclosure

I am the founder/operator of Mydentify. This is a factual, single-link addition with no tracking parameters.

## Validation

- Confirmed Mydentify was not already listed or proposed
- Confirmed the homepage returns HTTP 200
- Ran `git diff --check`
