### PR TITLE
Add AIWget to AI & Tool-Focused Launch Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Toolkitly](https://www.toolkitly.com) – Platform for tech tool discussions and discoveries.
 - [MagicBox Tools](https://magicbox.tools/) – Curated tools and startup products.
 - [Twelve Tools](https://twelve.tools/) – Directory of useful tools for founders and builders.
+- [AIWget](https://aiwget.com) – Curated directory for discovering AI agents, workflow automation tools, and creative AI products.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds AIWget to the **AI & Tool-Focused Launch Directories** section using the repository’s existing one-line format.

## Why

AIWget is a curated directory for discovering AI agents, workflow automation tools, and creative AI products. It fits this section’s focus on AI and tool discovery platforms.

- Website: https://aiwget.com
- Submission page: https://aiwget.com/submit
- Listing model: paid submission; approved listings remain published permanently

## Disclosure

I am the founder/operator of AIWget. The README entry uses the clean homepage URL without tracking parameters.

## Validation

- Confirmed AIWget is not already listed or proposed
- Confirmed the homepage and submission page are live
- Only `README.md` is changed, with one line added