### PR TITLE
Add AISOTools to AI & Tool-Focused Launch Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Toolkitly](https://www.toolkitly.com) – Platform for tech tool discussions and discoveries.
 - [MagicBox Tools](https://magicbox.tools/) – Curated tools and startup products.
 - [Twelve Tools](https://twelve.tools/) – Directory of useful tools for founders and builders.
+- [AISOTools](https://aisotools.com) – AI tools directory with a free listing plus AI-search visibility monitoring, so makers can see whether ChatGPT and Perplexity actually recommend their tool.
 
 ---
 


### PR DESCRIPTION
Adds **AISOTools** (https://aisotools.com) to the *AI & Tool-Focused Launch Directories* section, next to Altern / AI Directory / uNeed.

**What it is:** a directory where makers submit an AI tool and get a permanent dofollow listing, plus an AI-search visibility check that shows whether ChatGPT, Perplexity and Google AI Overviews actually name their tool when someone asks for a recommendation in its category.

**Fit for this list:** it is a submission destination, which is what this section is for — submissions open at https://aisotools.com/submit.

**Disclosure on pricing, so nothing is misleading:** listing is free. There is an optional $39 one-time fee that only skips the review queue; it is not required to be listed. Happy to have that wording included in the entry, or to shorten the description, if you'd prefer.

Disclosure: I maintain AISOTools. One line added, existing entries untouched, house bullet style matched.