### PR TITLE
Add The Agents Index to AI & Tool-Focused Launch Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Twelve Tools](https://twelve.tools/) – Directory of useful tools for founders and builders.
 - [AIWget](https://aiwget.com) – Curated directory for discovering AI agents, workflow automation tools, and creative AI products.
 - [AISOTools](https://aisotools.com) – AI tools directory with a free listing plus AI-search visibility monitoring, so makers can see whether ChatGPT and Perplexity actually recommend their tool.
+- [The Agents Index](https://theagentsindex.com) – Researched, quality-gated directory of AI agents and agentic tools, with pricing, verdicts, and comparisons for each listing.
 
 ---
 


### PR DESCRIPTION
Adds **The Agents Index** (https://theagentsindex.com) to the "AI & Tool-Focused Launch Directories" section, alongside the other AI-tool directories already listed there (AIWget, AISOTools, etc.).

The Agents Index is a researched, quality-gated directory of AI agents, frameworks and agentic tools — every listing carries structured fields (pricing, key features, use cases, a written verdict, sources) and has to clear a quality gate before it publishes, so it's a genuine directory rather than a bulk-generated list.

Single-line addition, matches the existing entry format and section.