### PR TITLE
Add CitedIndex to AI & Tool-Focused Launch Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Twelve Tools](https://twelve.tools/) – Directory of useful tools for founders and builders.
 - [AIWget](https://aiwget.com) – Curated directory for discovering AI agents, workflow automation tools, and creative AI products.
 - [AISOTools](https://aisotools.com) – AI tools directory with a free listing plus AI-search visibility monitoring, so makers can see whether ChatGPT and Perplexity actually recommend their tool.
+- [The Agents Index](https://theagentsindex.com) – Researched, quality-gated directory of AI agents and agentic tools, with pricing, verdicts, and comparisons for each listing.
+- [CitedIndex](https://citedindex.com) – Researched, quality-gated directory of AI-visibility & GEO tools: the tools that measure and improve how ChatGPT, Perplexity, Gemini and AI Overviews see and cite your brand.
 
 ---
 


### PR DESCRIPTION
Adds [CitedIndex](https://citedindex.com) to the "AI & Tool-Focused Launch Directories" section, right after The Agents Index (which is already listed here).

CitedIndex is a researched, quality-gated directory of AI-visibility & GEO tools — the tools that measure and improve how ChatGPT, Perplexity, Gemini and AI Overviews see and cite a brand. Same category and format as the other entries in this section.