### PR TITLE
Remove Startup & Tool Directories section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [AISOTools](https://aisotools.com) – AI tools directory with a free listing plus AI-search visibility monitoring, so makers can see whether ChatGPT and Perplexity actually recommend their tool.
 - [The Agents Index](https://theagentsindex.com) – Researched, quality-gated directory of AI agents and agentic tools, with pricing, verdicts, and comparisons for each listing.
 - [CitedIndex](https://citedindex.com) – Researched, quality-gated directory of AI-visibility & GEO tools: the tools that measure and improve how ChatGPT, Perplexity, Gemini and AI Overviews see and cite your brand.
+- [Best Directories](https://bestdirectories.org/) – Curated list of startup and product directories.
+- [Startup Fame](https://startupfa.me) – Product listings and startup discovery.
+- [Findly Tools](https://findly.tools) – Tool discovery and backlink listings.
+- [AIWith.me](https://aiwith.me) – AI and tool showcase platform.
+- [SaaSCity](https://saascity.io) – Gamified SaaS directory where every listing becomes a building on a live isometric city map.
+- [Mydentify](https://mydentify.com) – Goal-based product discovery with reviewed listings and a researched launch-directory catalog.
 
 ## Indie Maker Communities
 
@@ -73,17 +79,6 @@ A curated list of **product launch platforms, communities, and directories** whe
 - [Side Projectors](https://www.sideprojectors.com) – Promote or sell your side project.
 - [Remote Tools](https://www.remote.tools) – Tools focused on remote teams and distributed work.
 - [ToolFinder](https://toolfinder.wiki) – Browse productivity and SaaS tools.
-
-## Startup & Tool Directories (Visibility & Backlinks)
-
-> These platforms are especially useful for SEO, backlinks, and discoverability.
-
-- [Best Directories](https://bestdirectories.org/) – Curated list of startup and product directories.
-- [Startup Fame](https://startupfa.me) – Product listings and startup discovery.
-- [Findly Tools](https://findly.tools) – Tool discovery and backlink listings.
-- [AIWith.me](https://aiwith.me) – AI and tool showcase platform.
-- [SaaSCity](https://saascity.io) – Gamified SaaS directory where every listing becomes a building on a live isometric city map.
-- [Mydentify](https://mydentify.com) – Goal-based product discovery with reviewed listings and a researched launch-directory catalog.
 
 ## Launch Tools
 


### PR DESCRIPTION
Removed the 'Startup & Tool Directories' section from the README, which included various platforms for SEO and backlinks.